### PR TITLE
Adds the `blur` event to the EventRelay list

### DIFF
--- a/src/js/select2/selection/eventRelay.js
+++ b/src/js/select2/selection/eventRelay.js
@@ -9,7 +9,8 @@ define([
       'open', 'opening',
       'close', 'closing',
       'select', 'selecting',
-      'unselect', 'unselecting'
+      'unselect', 'unselecting',
+      'blur'
     ];
 
     var preventableEvents = ['opening', 'closing', 'selecting', 'unselecting'];


### PR DESCRIPTION
This allows clients of select2 to listen to the `select2:blur` event that was removed from v4 of select2.

This has been discussed in https://github.com/select2/select2/issues/1908.
